### PR TITLE
Corrected namespace to ApiRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ happen behind the scenes.
 
 namespace App\Http\Requests;
 
-use LaravelApiBase\ApiRequest;
+use LaravelApiBase\Http\Requests\ApiRequest;
 
 class TodoRequest extends ApiRequest
 {


### PR DESCRIPTION
Changed namespace from LaravelApiBase\ApiRequest to LaravelApiBase\Http\Requests\ApiRequest